### PR TITLE
fix bugs in update of offset/lock: missing function ref, bad scoping …

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build-example": "rollup -c",
     "test": "exit 0",
     "version": "npm run dist && npm run build-example",
-    "release": "np --no-publish && npm publish"
+    "release": "np --no-publish && npm publish",
+    "prepare": "npm run dist"
   },
   "main": "./dist/vue-scroll-monitor.js",
   "module": "./dist/vue-scroll-monitor.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-scrollmonitor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Use scrollMonitor with Vue.js",
   "author": "Alexandre Bonaventure <alex@la-bonaventure.com>",
   "scripts": {

--- a/src/vue-scrollmonitor.js
+++ b/src/vue-scrollmonitor.js
@@ -114,6 +114,9 @@ export const ScrollContainer = {
       })
       this.$emit('change', { ...this.state })
     },
+    recalculate () {
+      if (this._container) this._container.recalculateLocations()
+    },
     log (...args) {
       if (this.debug) console.log(...args)
     },

--- a/src/vue-scrollmonitor.js
+++ b/src/vue-scrollmonitor.js
@@ -9,6 +9,7 @@ export const ScrollContainer = {
     const $scrollMonitor = {
       registerWatcher: this.registerWatcher,
       unregisterWatcher: this.unregisterWatcher,
+      updateWatcher: this.updateWatcher,
     }
     Object.defineProperty($scrollMonitor, 'state', {
       get : () => this.state,
@@ -27,10 +28,8 @@ export const ScrollContainer = {
   data: () => ({
     state: {},
   }),
-  beforeMount () {
-    this.$nextTick(() => {
-      this.setupContainer()
-    })
+  mounted () {
+	  this.setupContainer()
   },
   destroyed () {
     this.teardownWatchers()
@@ -55,10 +54,10 @@ export const ScrollContainer = {
       }
       this.$emit('change', { ...this.state })
     },
-    setupContainer (children) {
+    setupContainer () {
       this._container = this.container
-        ? scrollMonitor.createContainer(this.$el)
-        : scrollMonitor
+          ? scrollMonitor.createContainer(this.$el)
+          : scrollMonitor
     },
     teardownWatchers () {
       this._scrollWatchers.map(watcher => watcher.destroy())
@@ -162,9 +161,9 @@ export const ScrollItem = {
   //     this._scrollwatcher.lock()
   //   }
   // },
-  beforeMount () {
-    this.$nextTick(() => {
-      this._scrollwatcher = this.$scrollMonitor.registerWatcher(this.id, this.$el, { offset: this.offset, lock: this.lock })
+  mounted () {
+      this.$nextTick( function () {
+          this._scrollwatcher = this.$scrollMonitor.registerWatcher(this.id, this.$el, { offset: this.offset, lock: this.lock })
     })
   },
   destroyed () {
@@ -176,11 +175,11 @@ export const ScrollItem = {
     }
   },
   watch: {
-    lock(val) {
+    lock: function (val) {
       this.$scrollMonitor.updateWatcher(this.id, this.$el, { lock: val })
     },
     offset: {
-      handler() {
+      handler: function (val) {
         this.$scrollMonitor.updateWatcher(this.id, this.$el, { offset: val })
       },
       deep: true,
@@ -192,3 +191,4 @@ export default {
   ScrollContainer,
   ScrollItem,
 }
+


### PR DESCRIPTION
…on watch and mount hooks

Tried to use the update of offset (on a screen resize event) and got a series of errors from the module:
- missing updateWatcher method on $scrollMonitor
- in vue, you can't use arrow functions on watchers if you need 'this' to resolve to the component
- beforeMount nextTick doesn't seem to work (_container never initialized), changed to mounted on ScrollContainer (since that is effectively 'mount started') and mounted/nextTick on ScrollItem ('mount finished')
